### PR TITLE
correct the URL that is embeded with the message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -78,7 +78,7 @@ async def sub_messages():
                     else:
                         eventloc = "Online"
                     embed.title = f"{current['name']}"
-                    embed.url = f'https://v1.oengus.io' \
+                    embed.url = f'https://oengus.io' \
                                 f'/marathon/{current["id"]}'
                     if d['description'] and len(d['description']) > 500:
                         embed.description = ''.join([str(d['description'])[0:500], "..."])


### PR DESCRIPTION
The marathon bot in our FF6WC chat has the wrong embed link. If you remove the v1. manually from the link that is shown, it does go to the right URL, thus it needs to be corrected.

Without the fix:
![image](https://github.com/user-attachments/assets/c6f6cb85-c1f5-42ed-be55-89f6fc08290d)

With the fix::
![image](https://github.com/user-attachments/assets/dbbebb7d-ec94-4c99-8a77-6e445aceb994)
